### PR TITLE
Fix some typos, partial templates guide rewrite

### DIFF
--- a/src/content/docs/guides/inputFields.md
+++ b/src/content/docs/guides/inputFields.md
@@ -47,7 +47,7 @@ INPUT[toggle:completed]
 And our input field is working. The toggle will change the frontmatter and when the frontmatter changes, the toggle changes.
 
 Specifying a bind target is optional, but recommended.
-If you don't specify a bind target, the input field will not preserve its state when you reopen the note or restart obsidian, since the input field has nowhere to store its data.
+If you don't specify a bind target, the input field will not preserve its state when you reopen the note or restart Obsidian, since the input field has nowhere to store its data.
 
 ### Binding to Metadata of a different note
 

--- a/src/content/docs/guides/installation.md
+++ b/src/content/docs/guides/installation.md
@@ -3,6 +3,6 @@ title: Installation
 description: How to install Meta Bind.
 ---
 
-The easiest way to install the plugin is through obsidian's plugin browser.
+The easiest way to install the plugin is through Obsidian's plugin browser.
 
 [Here is a quick link to it.](https://obsidian.md/plugins?search=meta%20bind#)

--- a/src/content/docs/guides/obsidianPublish.md
+++ b/src/content/docs/guides/obsidianPublish.md
@@ -3,9 +3,9 @@ title: Obsidian Publish Support
 description: A tutorial for setting up Meta Bind to work in publish.
 ---
 
-This guide assumes that you already have obsidian publish set up with a custom domain, so that you can use a `publish.js` file.
+This guide assumes that you already have Obsidian Publish set up with a custom domain, so that you can use a `publish.js` file.
 
-To get meta bind working in obsidian publish, you need to copy the contents of [this file](https://github.com/mProjectsCode/obsidian-meta-bind-plugin/blob/master/PublishLoad.js) into your `publish.js` file.
+To get meta bind working in Obsidian Publish, you need to copy the contents of [this file](https://github.com/mProjectsCode/obsidian-meta-bind-plugin/blob/master/PublishLoad.js) into your `publish.js` file.
 For the correct appearance, you need to copy [this file](https://github.com/mProjectsCode/obsidian-meta-bind-plugin/blob/master/styles.css) into your `publish.css` file.
 
 ## What it can do and what it can't

--- a/src/content/docs/guides/templates.md
+++ b/src/content/docs/guides/templates.md
@@ -3,36 +3,34 @@ title: Templates
 description: A tutorial for Meta Bind Templates.
 ---
 
-Templates allow you to reuse input fields across your vault. You can specify them in the plugins settings.
+Templates allow you to reuse input fields across your vault.
+You can specify them in the plugins settings.
 
 ## Using Templates
 
-First we need to create a template in the plugin settings. Let's create the following template.
+First, we need to create a template in the plugin settings.
+Let's create a template for a slider as follows.
 
 | Template Name    | Template String                                      |
 |------------------|------------------------------------------------------|
 | `sliderTemplate` | `INPUT[slider(addLabels, minValue(0), maxValue(10)]` |
 
-Notice that the template is not bound to any metadata.
+Notice that the template is **not** bound to any metadata.
 
-Then we can go into our note and use the template.
-
-To use the template we need to follow the following syntax.
+To use the template, we open a note and write the following.
 
 ```
 INPUT[templateName][overrides]
 ```
 
-Where `overrides` may consist of an input field type, arguments and a bind target. 
-Overrides can also be empty if you don't want to override anything.
+Here, `overrides` may consist of an input field type, arguments and a bind target.
+It can also be empty if you don't want to override anything from the template.
 
-In our case this would look like this.
+For example, if we want to use the `sliderTemplate` for some `rating` we have in frontmatter, we would write:
 
 ```
 INPUT[sliderTemplate][:rating]
 ```
 
-We use the `sliderTemplate` as the base and adds a bind target pointing to `rating`.
-
-
+We have set `templateName` to `sliderTemplate` (telling meta-bind to use the template we created earlier), and in the `overrides` we bind the input field to the frontmatter property `rating`.
 

--- a/src/content/docs/guides/viewFields.mdx
+++ b/src/content/docs/guides/viewFields.mdx
@@ -90,7 +90,7 @@ VIEW[{a} * {b}][math:c]
 
 ### Circular Dependencies
 
-Of-course you can abuse this and create circular dependencies that cause obsidian to crash by doing something like the following example.
+Of course you can abuse this and create circular dependencies that cause Obsidian to crash by doing something like the following example.
 
 ```
 VIEW[{a}][math:b]
@@ -103,7 +103,7 @@ Or like this.
 VIEW[{a + 1}][math:a]
 ```
 
-Meta Bind **will detect** these dependency loops and **will prevent** you accidentally locking yourself out of obsidian and your notes.
+Meta Bind **will detect** these dependency loops and **will prevent** you accidentally locking yourself out of Obsidian and your notes.
 
 ### Limitations
 
@@ -158,7 +158,7 @@ There are multiple global variables available in the JS section.
 
 | Name       | Description                                                                                 |
 |------------|---------------------------------------------------------------------------------------------|
-| `app`      | Reference to the obsidian app instance.                                                     | 
+| `app`      | Reference to the Obsidian app instance.                                                     | 
 | `mb`       | Reference to the meta-bind api.                                                             |
 | `dv`       | Reference to the dataview api, if dataview is installed and enabled.                        | 
 | `filePath` | The file path of the note that is view field is in.                                         |


### PR DESCRIPTION
This PR fixes some typos, and partially rewrites the `Templates` guide.