### PR TITLE
Docs: Reference/Input Fields

### DIFF
--- a/src/content/docs/reference/inputFields/date.mdx
+++ b/src/content/docs/reference/inputFields/date.mdx
@@ -10,7 +10,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.DATE}></InputFieldInfo>
 
-A date input consists of three inputs, for the day, month and year.
+A _date_ input field consists of three inputs: the day, the month, and the year.
 
 ### Allowed Arguments
 

--- a/src/content/docs/reference/inputFields/datePicker.mdx
+++ b/src/content/docs/reference/inputFields/datePicker.mdx
@@ -10,7 +10,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.DATE_PICKER}></InputFieldInfo>
 
-A simple data picker that treats null as no set date.
+A _date picker_ input field is a simple data picker that treats `null` as no set date.
 
 ### Allowed Arguments
 

--- a/src/content/docs/reference/inputFields/editor.mdx
+++ b/src/content/docs/reference/inputFields/editor.mdx
@@ -6,11 +6,12 @@ description: Editor input field reference.
 import InputFieldInfo from '../../../../components/inputField/InputFieldInfo.astro';
 import InputFieldAllowedArguments from '../../../../components/inputField/InputFieldAllowedArguments.astro';
 import InputFieldArgumentLink from '../../../../components/inputField/InputFieldArgumentLink.astro';
+import InputFieldLink from '../../../../components/inputField/InputFieldLink.astro';
 import { InputFieldArgumentType, InputFieldType } from '../../../../config/static.js';
 
 <InputFieldInfo type={InputFieldType.EDITOR}></InputFieldInfo>
 
-A text area but with full markdown support.
+An _editor_ input field is similar to a <InputFieldLink type={InputFieldType.TEXT_AREA}></InputFieldLink>, but with full markdown support.
 
 ### Allowed Arguments
 

--- a/src/content/docs/reference/inputFields/imageSuggester.mdx
+++ b/src/content/docs/reference/inputFields/imageSuggester.mdx
@@ -10,7 +10,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.IMAGE_SUGGESTER}></InputFieldInfo>
 
-Allows selection from a gallery of images.
+An _image suggester_ input field allows for a selection from a gallery of images.
 
 ### Allowed Arguments
 

--- a/src/content/docs/reference/inputFields/inlineSelect.mdx
+++ b/src/content/docs/reference/inputFields/inlineSelect.mdx
@@ -11,7 +11,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 <InputFieldInfo type={InputFieldType.INLINE_SELECT}></InputFieldInfo>
 
 
-A inline select functions like a dropdown menu and allows you to select a certain value from a list of options.
+An _inline select_ input field functions like a dropdown menu, and allows you to select a certain value from a list of options.
 Options can be added using the <InputFieldArgumentLink type={InputFieldArgumentType.OPTION}></InputFieldArgumentLink> argument.
 
 ### Allowed Arguments

--- a/src/content/docs/reference/inputFields/list.mdx
+++ b/src/content/docs/reference/inputFields/list.mdx
@@ -10,7 +10,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.LIST}></InputFieldInfo>
 
-A list input allows you to add and remove elements to a list.
+A _list_ input field allows you to add and remove elements to a list.
 
 ### Allowed Arguments
 

--- a/src/content/docs/reference/inputFields/listSuggester.mdx
+++ b/src/content/docs/reference/inputFields/listSuggester.mdx
@@ -11,7 +11,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.LIST_SUGGESTER}></InputFieldInfo>
 
-A list suggester input allows you to add and remove elements to a list, using a <InputFieldLink type={InputFieldType.SUGGESTER}></InputFieldLink> input.
+A _list suggester_ input field allows you to add and remove elements to a list, using a <InputFieldLink type={InputFieldType.SUGGESTER}></InputFieldLink> input.
 
 
 ### Allowed Arguments

--- a/src/content/docs/reference/inputFields/multiSelect.mdx
+++ b/src/content/docs/reference/inputFields/multiSelect.mdx
@@ -10,7 +10,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.MULTI_SELECT}></InputFieldInfo>
 
-A multi select input field allows you to select multiple values from a list of options.
+A _multi select_ input field allows you to select multiple values from a list of options.
 Options can be added using the <InputFieldArgumentLink type={InputFieldArgumentType.OPTION}></InputFieldArgumentLink> argument.
 
 ### Allowed Arguments

--- a/src/content/docs/reference/inputFields/number.mdx
+++ b/src/content/docs/reference/inputFields/number.mdx
@@ -6,11 +6,12 @@ description: Number input field reference.
 import InputFieldInfo from '../../../../components/inputField/InputFieldInfo.astro';
 import InputFieldAllowedArguments from '../../../../components/inputField/InputFieldAllowedArguments.astro';
 import InputFieldArgumentLink from '../../../../components/inputField/InputFieldArgumentLink.astro';
+import InputFieldLink from '../../../../components/inputField/InputFieldLink.astro';
 import { InputFieldArgumentType, InputFieldType } from '../../../../config/static.js';
 
 <InputFieldInfo type={InputFieldType.NUMBER}></InputFieldInfo>
 
-A text input that only accepts numbers.
+A _number_ input field is a <InputFieldLink type={InputFieldType.TEXT}></InputFieldLink>-like input field that only accepts numbers.
 
 ### Allowed Arguments
 

--- a/src/content/docs/reference/inputFields/progressbar.mdx
+++ b/src/content/docs/reference/inputFields/progressbar.mdx
@@ -10,10 +10,10 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.PROGRESS_BAR}></InputFieldInfo>
 
-A progress bar takes the full width of the note and can move within a certain value range.
+A _progress bar_ input field takes the full width of a note and can move within a certain value range.
 The range can be controlled with the <InputFieldArgumentLink type={InputFieldArgumentType.MIN_VALUE}></InputFieldArgumentLink>
 and <InputFieldArgumentLink type={InputFieldArgumentType.MAX_VALUE}></InputFieldArgumentLink> arguments.
-Optionally labels can be added using the <InputFieldArgumentLink type={InputFieldArgumentType.ADD_LABELS}></InputFieldArgumentLink> argument.
+Optionally, labels can be added using the <InputFieldArgumentLink type={InputFieldArgumentType.ADD_LABELS}></InputFieldArgumentLink> argument.
 
 ### Allowed Arguments
 

--- a/src/content/docs/reference/inputFields/select.mdx
+++ b/src/content/docs/reference/inputFields/select.mdx
@@ -10,8 +10,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.SELECT}></InputFieldInfo>
 
-
-A select input field allows you to select a certain value from a list of options.
+A _select_ input field allows you to select a certain value from a list of options.
 Options can be added using the <InputFieldArgumentLink type={InputFieldArgumentType.OPTION}></InputFieldArgumentLink> argument.
 
 ### Allowed Arguments

--- a/src/content/docs/reference/inputFields/slider.mdx
+++ b/src/content/docs/reference/inputFields/slider.mdx
@@ -10,10 +10,10 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.SLIDER}></InputFieldInfo>
 
-A slider can move within a certain value range.
+A _slider_ input field is a slider that can move within a certain value range.
 The range can be controlled with the <InputFieldArgumentLink type={InputFieldArgumentType.MIN_VALUE}></InputFieldArgumentLink>
 and <InputFieldArgumentLink type={InputFieldArgumentType.MAX_VALUE}></InputFieldArgumentLink> arguments.
-Optionally labels can be added using the <InputFieldArgumentLink type={InputFieldArgumentType.ADD_LABELS}></InputFieldArgumentLink> argument.
+Optionally, labels can be added using the <InputFieldArgumentLink type={InputFieldArgumentType.ADD_LABELS}></InputFieldArgumentLink> argument.
 
 ### Allowed Arguments
 

--- a/src/content/docs/reference/inputFields/suggester.mdx
+++ b/src/content/docs/reference/inputFields/suggester.mdx
@@ -10,7 +10,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.SUGGESTER}></InputFieldInfo>
 
-Allows selection from a fuzzy search modal.
+A _suggester_ input fields allows selection from a fuzzy search modal. 
 
 ### Allowed Arguments
 

--- a/src/content/docs/reference/inputFields/text.mdx
+++ b/src/content/docs/reference/inputFields/text.mdx
@@ -10,7 +10,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.TEXT}></InputFieldInfo>
 
-A simple inline text input field.
+A _text_ input field is simple inline text input field. Markdown is _not_ supported.
 
 ### Allowed Arguments
 

--- a/src/content/docs/reference/inputFields/textArea.mdx
+++ b/src/content/docs/reference/inputFields/textArea.mdx
@@ -10,7 +10,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.TEXT_AREA}></InputFieldInfo>
 
-A simple text area input field.
+A _text area_ input field is a simple text area input field. Markdown is _not_ supported.
 
 ### Allowed Arguments
 

--- a/src/content/docs/reference/inputFields/time.mdx
+++ b/src/content/docs/reference/inputFields/time.mdx
@@ -10,7 +10,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldInfo type={InputFieldType.TIME}></InputFieldInfo>
 
-A time input consists of two inputs, for the minute and hour.
+A _time_ input field consists of two inputs: the minute, and the hour.
 
 ### Allowed Arguments
 

--- a/src/content/docs/reference/inputFields/toggle.mdx
+++ b/src/content/docs/reference/inputFields/toggle.mdx
@@ -9,7 +9,7 @@ import { InputFieldType } from '../../../../config/static.js';
 
 <InputFieldInfo type={InputFieldType.TOGGLE}></InputFieldInfo>
 
-A toggle is a switch that can be toggled between true and false.
+A _toggle_ input field acts like a switch that can be toggled between `true` and `false`.
 
 ### Allowed Arguments
 


### PR DESCRIPTION
Rewrite the input fields doc pages for consistency. I have chosen to format every reference page as follows, where `INPUT_FIELD_NAME` refers to the common name of an input field, e.g. `image suggester` or `text area`.

```text
A(n) _{INPUT_FIELD_NAME} input field ...
```