### PR TITLE
Reference/InputFieldArguments: Process input field argument files

### DIFF
--- a/src/content/docs/reference/inputFieldArguments/limit.mdx
+++ b/src/content/docs/reference/inputFieldArguments/limit.mdx
@@ -11,7 +11,8 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldArgumentInfo type={InputFieldArgumentType.LIMIT}></InputFieldArgumentInfo>
 
-The `limit` argument allows you to limit the length of a value that can be entered into some input fields.
+The `limit` argument allows you to limit the length of a value that can be entered in the <InputFieldLink type={InputFieldType.TEXT}> </InputFieldLink>, <InputFieldLink type={InputFieldType.TEXT_AREA}> </InputFieldLink>, and <InputFieldLink type={InputFieldType.LIST}> </InputFieldLink> input fields.
+The value passed to this argument must be a number.
 
 ### Values
 

--- a/src/content/docs/reference/inputFieldArguments/optionQuery.mdx
+++ b/src/content/docs/reference/inputFieldArguments/optionQuery.mdx
@@ -11,8 +11,8 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldArgumentInfo type={InputFieldArgumentType.OPTION_QUERY}></InputFieldArgumentInfo>
 
-The `optionQuery` argument lets you add multiple options based on a [dataview data source](https://blacksmithgu.github.io/obsidian-dataview/reference/sources/).
-The <InputFieldLink type={InputFieldType.IMAGE_SUGGESTER}></InputFieldLink> input only supports folders with `"path/to/folder"`.
+The `optionQuery` argument lets you add multiple options to suggesters based on a [dataview data source](https://blacksmithgu.github.io/obsidian-dataview/reference/sources/). 
+Note that <InputFieldLink type={InputFieldType.IMAGE_SUGGESTER}></InputFieldLink> only supports providing a `"path/to/folder"`, whereas <InputFieldLink type={InputFieldType.SUGGESTER}></InputFieldLink> and <InputFieldLink type={InputFieldType.LIST_SUGGESTER}></InputFieldLink> fully support any dataview data source.
 
 ### Values
 

--- a/src/content/docs/reference/inputFieldArguments/useLinks.mdx
+++ b/src/content/docs/reference/inputFieldArguments/useLinks.mdx
@@ -11,7 +11,7 @@ import { InputFieldArgumentType, InputFieldType } from '../../../../config/stati
 
 <InputFieldArgumentInfo type={InputFieldArgumentType.USE_LINKS}></InputFieldArgumentInfo>
 
-The `useLinks` argument lets you disable the usage of links for certain input fields.
+The `useLinks` argument lets you disable the usage of links for <InputFieldLink type={InputFieldType.SUGGESTER}></InputFieldLink> and <InputFieldLink type={InputFieldType.LIST_SUGGESTER}></InputFieldLink>. If no value is provided, `true` will be used for the value.
 
 ### Values
 


### PR DESCRIPTION
This PR rewords some of the input field argument documentation pages to be explicit about the input field types they are allowed for. It also fixes a typo in a filename (`ueLinks -> useLinks`).