### PR TITLE
Remove "discontinued" from buttons callout

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -11,7 +11,7 @@ import Pride from '../../components/Pride.astro';
 {/* <Pride></Pride> */}
 
 :::tip
-**New**: Meta Bind [Buttons](/obsidian-meta-bind-plugin-docs/guides/buttons/), a spiritual successor to the discontinued [Buttons Plugin](https://github.com/shabegom/buttons).
+**New**: Meta Bind [Buttons](/obsidian-meta-bind-plugin-docs/guides/buttons/), a spiritual successor to the [Buttons Plugin](https://github.com/shabegom/buttons).
 :::
 
 Meta Bind is a plugin for [Obsidian](https://obsidian.md/) to make your notes interactive!


### PR DESCRIPTION
A small PR that removes "discontinued" when mentioning Buttons. I've started maintaining Buttons again, so it is no longer discontinued.

Thank you!